### PR TITLE
Use Memory Type Variable Instead of Storage Type Variable in Event to Save Gas

### DIFF
--- a/Mainnet-token-contracts-20180610/contracts/0xf244176246168f24e3187f7288edbca29267739b-HAV-Havven.sol
+++ b/Mainnet-token-contracts-20180610/contracts/0xf244176246168f24e3187f7288edbca29267739b-HAV-Havven.sol
@@ -1289,7 +1289,7 @@ contract EtherNomin is ExternStateProxyFeeToken {
 
         etherPrice = initialEtherPrice;
         lastPriceUpdate = now;
-        emit PriceUpdated(etherPrice);
+        emit PriceUpdated(initialEtherPrice);
 
         // It should not be possible to transfer to the nomin contract itself.
         frozen[this] = true;

--- a/contracts/FlexibleToken.sol
+++ b/contracts/FlexibleToken.sol
@@ -129,7 +129,7 @@ contract FlexibleToken is ERC20Interface, Owned {
         decimals = _decimals;
         _totalSupply = _initialSupply;
         balances[owner] = _totalSupply;
-        emit Transfer(address(0), owner, _totalSupply);
+        emit Transfer(address(0), owner, _initialSupply);
     }
     function lock() public onlyOwner {
         require(!locked);


### PR DESCRIPTION
Hi, we are a research group on programming languages and software engineering. We recently have conducted a systematic study about Solidity event usage, evolution, and impact, and we are attempting to build a tool to improve the practice of Solidity event use based on our findings. We have tried our prototype tool on some of the most popular GitHub Solidity repositories, and for your repository, we find a potential optimization of gas consumption arisen from event use.  

The point is that when we use emit operation to store the value of a certain variable, `local memory type variable` would be preferable to `storage type (state) variable` if they hold the same value. The reason is that an extra SLOAD operation would be needed to access the variable if it is storage type, and the SLOAD operation costs 800 gas.

For your repository, we find that several event uses can be improved.